### PR TITLE
fix minor error in uint8 array

### DIFF
--- a/docs/Array.md
+++ b/docs/Array.md
@@ -11,7 +11,7 @@ contract Array {
 /*
 *   Array Variable    |   Slot(s) Occupied    |   Values Stored At Slot(s) [sload(slot)]
 *   __________________|_______________________|_____________________________________________________
-*   fixedU8Array      |   0 - 2               |   0 <= x <= 2 
+*   fixedU8Array      |   0                   |   (8 * (0 <= x <= 2)) >> 0 && 0xff
 *   dynamicU8Array    |   3                   |   keccak256(3) + (0 <= x < dynamicU8Array.length)
 *   fixedU256Array    |   4 - 6               |   4 <= x <= 6
 *   dynamicU256Array  |   7                   |   keccak256(7) + (0 <= x < dynamicU256Array.length)

--- a/src/Array.sol
+++ b/src/Array.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 contract Array {
     // Declare array variables.
-    uint256[3] fixedArray; // Elements stored @ slots 0, 1, 2.
+    uint8[3] fixedArray; // Elements stored @ slots 0, 1, 2.
     uint256[] dynamicArray; // Length stored @ slot 3, elements in slots keccak256(3) to (keccak256(3) + (length - 1)).
     uint8[] smallArray; // Slot keccak256(4).
 
@@ -18,6 +18,7 @@ contract Array {
         assembly {
             // Get slot of fixed array.
             let slot := fixedArray.slot
+            let offset := mul(_index, 0x08)
 
             // Fixed arrays are not stored at the locations of the hash of their slots.
             // This is because, the length of the array has already been defined and it's slots can be
@@ -26,7 +27,7 @@ contract Array {
             // The value at index 0 takes the first storage slot, followed by the subsequent indexes.
             // Info: https://rb.gy/yvbfwf.
             // Increment slot by the index we want to read.
-            ret := sload(add(slot, _index))
+            ret := and(shr(offset, sload(0)), 0xff)
         }
     }
 

--- a/test/Array.t.sol
+++ b/test/Array.t.sol
@@ -13,8 +13,12 @@ contract ArrayTest is Test {
 
     function testReadFixedArray() public {
         // fixedArray - [10, 20, 30]
-        uint256 ret = array.readFixedArray(0);
-        assertEq(ret, 10);
+        uint256 ret0 = array.readFixedArray(0);
+        uint256 ret1 = array.readFixedArray(1);
+        uint256 ret2 = array.readFixedArray(2);
+        assertEq(ret0, 10);
+        assertEq(ret1, 20);
+        assertEq(ret2, 30);
     }
 
     function testreadDynamicArray() public {


### PR DESCRIPTION

## minor error in uint8 array slot position

### Body
The array elements are all stored in slot 0, as opposed to what was stated in the docs, this PR updates the contract to use uint8[] as stated in the docs, and containts unit tests to justify the updates.

### Review Request
[@0xfps ]
