### PR TITLE
Updated 'Fallback' link

### DIFF
--- a/book/book/Fallback.html
+++ b/book/book/Fallback.html
@@ -149,7 +149,7 @@
 <p>OR</p>
 <pre><code class="language-solidity">fallback() external payable {}
 </code></pre>
-<p>In our <a href="../src/Fallback.sol">Fallback</a> contract, it sends <code>1 Wei</code> to any caller.</p>
+<p>In our <a href="https://github.com/Perelyn-sama/yul_by_example/blob/main/src/Fallback.sol">Fallback</a> contract, it sends <code>1 Wei</code> to any caller.</p>
 
                     </main>
 

--- a/book/src/Fallback.md
+++ b/book/src/Fallback.md
@@ -11,4 +11,4 @@ OR
 fallback() external payable {}
 ```
 
-In our [Fallback](../src/Fallback.sol) contract, it sends `1 Wei` to any caller.
+In our [Fallback](https://github.com/Perelyn-sama/yul_by_example/blob/main/src/Fallback.sol) contract, it sends `1 Wei` to any caller.


### PR DESCRIPTION
The link to 'fallback' contract didn't work on page - https://yul-by-example.vercel.app/Fallback.html

So, pointed it down to the file present in this repo!